### PR TITLE
Bundle rusqlite on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.0.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66120af515773fb005778dc07c261bd201ec8ce50bd6e7144c927753fe013381"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +203,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e704a02bcaecd4a08b93a23f6be59d0bd79cd161e0963e9499165a0a35df7bd"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,13 @@ panic = 'abort'
 [dependencies]
 chrono = "0.4"
 uuid = { version = "0.8", features = ["v4"] }
-rusqlite = { version = "0.23.1", features = ["chrono"] }
 structopt = "0.3"
 exitcode = "1.1.2"
 dirs = "2.0.2"
+
+[target.'cfg(not(windows))'.dependencies]
+rusqlite = { version = "0.23.1", features = ["chrono"] }
+
+[target.'cfg(windows)'.dependencies]
+rusqlite = { version = "0.23.1", features = ["chrono", "bundled"] }
+


### PR DESCRIPTION
Rusqlite links to the sqlite3 lib by default. On Unix systems, this is either `sqlite3.a` or `libsqlite3.so`. On Windows, this is `sqlite3.lib`.

Few Windows installations have `sqlite3.lib`, resulting in compile errors:

```
   Compiling ttrack v0.1.0
error: linking with `link.exe` failed: exit code: 1181
...
  = note: LINK : fatal error LNK1181: cannot open input file 'sqlite3.lib'
```

This patch enables "bundled" mode for sqlite, which compiles `sqlite3.lib` on those platforms.